### PR TITLE
ueventd.qcom.rc: set permissions of /dev/qce device

### DIFF
--- a/rootdir/vendor/ueventd.rc
+++ b/rootdir/vendor/ueventd.rc
@@ -56,6 +56,7 @@
 /dev/media*               0660   system     camera
 /dev/v4l-subdev*          0660   system     camera
 /dev/qseecom              0660   system     drmrpc
+/dev/qce                  0660   system     drmrpc
 /dev/smcinvoke            0660   system     system
 /dev/qsee_ipc_irq_spss    0660   system     drmrpc
 /dev/seemplog             0660   system     system


### PR DESCRIPTION
To support end-to-end DRM content playback with SG List feature,
android.hardware.drm@1.0-service needs to have access permission
to /dev/qce to map & unmap ION buffer virtual address with HW Crypto
Engine. So, set /dev/qce device permission 0660 and let it be
accessible by user "system" and group "drmrpc".

Change-Id: If9c0ed70acc2bb063344692374f51441fe84eff6