### PR TITLE
[master] fstab: Update paths for k4.9

### DIFF
--- a/rootdir/vendor/etc/fstab.tama
+++ b/rootdir/vendor/etc/fstab.tama
@@ -12,6 +12,6 @@
 /dev/block/bootdevice/by-name/bluetooth    /bt_firmware vfat    ro,shortname=lower,uid=1002,gid=3002,dmask=227,fmask=337,context=u:object_r:bt_firmware_file:s0 wait,slotselect
 /dev/block/bootdevice/by-name/persist      /persist     ext4    noatime,nosuid,nodev,barrier=1,data=ordered,nodelalloc,errors=panic   wait,notrim
 
-/devices/soc/c084000.sdhci/mmc_host/mmc*                       auto         auto    nosuid,nodev                              voldmanaged=sdcard1:auto
-/devices/soc/a800000.ssusb/a800000.dwc3/xhci-hcd.0.auto/usb*   auto         auto    defaults                                  voldmanaged=usb:auto
-/dev/block/zram0                                               none         swap    defaults                                  zramsize=536870912,notrim
+/devices/platform/soc/c084000.sdhci/mmc_host/mmc*                       auto         auto    nosuid,nodev                     voldmanaged=sdcard1:auto
+/devices/platform/soc/a800000.ssusb/a800000.dwc3/xhci-hcd.0.auto/usb*   auto         auto    defaults                         voldmanaged=usb:auto
+/dev/block/zram0                            none        swap    defaults                                                      zramsize=536870912,notrim


### PR DESCRIPTION
On kernel 4.9, /sys/devices/soc has been moved
to /sys/devices/platform/soc.

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>