### PR TITLE
[master] ueventd.rc: Update paths for kernel 4.9

### DIFF
--- a/rootdir/vendor/ueventd.rc
+++ b/rootdir/vendor/ueventd.rc
@@ -144,23 +144,23 @@
 /dev/ttyMSM0                                0660 bluetooth bluetooth
 
 # NFC
-/dev/pn54x                                             0660 nfc nfc
-/sys/devices/soc/c1b5000.i2c/i2c-7/7-0028  init_deinit 0200 nfc nfc
-/sys/devices/soc/c1b5000.i2c/i2c-7/7-0028  set_pwr     0200 nfc nfc
-/sys/devices/soc/c1b5000.i2c/i2c-7/7-0028  res_ready   0400 nfc nfc
-/sys/devices/soc/c1b5000.i2c/i2c-7/7-0028  recv_rsp    0600 nfc nfc
-/sys/devices/soc/c1b5000.i2c/i2c-7/7-0028  send_cmd    0200 nfc nfc
+/dev/pn54x                                                      0660 nfc nfc
+/sys/devices/platform/soc/c1b5000.i2c/i2c-7/7-0028  init_deinit 0200 nfc nfc
+/sys/devices/platform/soc/c1b5000.i2c/i2c-7/7-0028  set_pwr     0200 nfc nfc
+/sys/devices/platform/soc/c1b5000.i2c/i2c-7/7-0028  res_ready   0400 nfc nfc
+/sys/devices/platform/soc/c1b5000.i2c/i2c-7/7-0028  recv_rsp    0600 nfc nfc
+/sys/devices/platform/soc/c1b5000.i2c/i2c-7/7-0028  send_cmd    0200 nfc nfc
 
 # LED
-/sys/devices/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pm660l@3:qcom,leds@d000/leds/led:* max_brightness 0664 system system
-/sys/devices/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pm660l@3:qcom,leds@d000/leds/led:* brightness     0664 system system
-/sys/devices/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pm660l@3:qcom,leds@d000/leds/led:* blink          0664 system system
-/sys/devices/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pm660l@3:qcom,leds@d000/leds/led:* duty_pcts      0664 system system
-/sys/devices/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pm660l@3:qcom,leds@d000/leds/rgb   rgb_blink      0664 system system
-/sys/devices/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pm660l@3:qcom,leds@d800/leds/wled  max_brightness 0664 system system
-/sys/devices/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pm660l@3:qcom,leds@d800/leds/wled  brightness     0664 system system
-/sys/class/leds/lcd-backlight max_brightness                                                                                0644 root system
-/sys/class/leds/lcd-backlight brightness                                                                                    0664 system system
+/sys/devices/platform/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pm660l@3:qcom,leds@d000/leds/led:* max_brightness 0664 system system
+/sys/devices/platform/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pm660l@3:qcom,leds@d000/leds/led:* brightness     0664 system system
+/sys/devices/platform/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pm660l@3:qcom,leds@d000/leds/led:* blink          0664 system system
+/sys/devices/platform/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pm660l@3:qcom,leds@d000/leds/led:* duty_pcts      0664 system system
+/sys/devices/platform/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pm660l@3:qcom,leds@d000/leds/rgb   rgb_blink      0664 system system
+/sys/devices/platform/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pm660l@3:qcom,leds@d800/leds/wled  max_brightness 0664 system system
+/sys/devices/platform/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pm660l@3:qcom,leds@d800/leds/wled  brightness     0664 system system
+/sys/class/leds/lcd-backlight max_brightness                                                                                         0644 root system
+/sys/class/leds/lcd-backlight brightness                                                                                             0664 system system
 
 # Fingerprint sensor  device
 /dev/fingerprint         0664 system input


### PR DESCRIPTION
On kernel 4.9, /sys/devices/soc has been moved
to /sys/devices/platform/soc.

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>