### PR TITLE
audio_platform_info: Change VOICE_SPEAKER ACDB ID

### DIFF
--- a/rootdir/vendor/etc/audio_platform_info.xml
+++ b/rootdir/vendor/etc/audio_platform_info.xml
@@ -31,6 +31,7 @@
         <device name="SND_DEVICE_OUT_SPEAKER_AND_BT_A2DP" acdb_id="799"/>
         <device name="SND_DEVICE_OUT_SPEAKER_AND_HEADPHONES" acdb_id="799"/>
         <device name="SND_DEVICE_OUT_SPEAKER_REVERSE" acdb_id="15"/>
+        <device name="SND_DEVICE_OUT_VOICE_SPEAKER" acdb_id="150"/>
         <device name="SND_DEVICE_OUT_VOICE_TTY_HCO_HANDSET" acdb_id="150"/>
 
         <device name="SND_DEVICE_IN_UNPROCESSED_USB_HEADSET_MIC" acdb_id="133"/>


### PR DESCRIPTION
Use correct ID for speaker mode while incall as found in stock logs