### PR TITLE
label 18800000.qcom,icnss/net as sysfs_net

### DIFF
--- a/sepolicy_platform/genfs_contexts
+++ b/sepolicy_platform/genfs_contexts
@@ -14,6 +14,7 @@ genfscon sysfs /devices/platform/soc/ac4a000.qcom,cci                           
 
 genfscon sysfs /devices/platform/soc/soc:fpc1145                                u:object_r:sysfs_fingerprint:s0
 
+genfscon sysfs /devices/platform/soc/18800000.qcom,icnss/net                    u:object_r:sysfs_net:s0
 
 genfscon sysfs /devices/platform/soc/c440000.qcom,spmi/spmi-0/spmi0-03/c440000.qcom,spmi:qcom,pmi8998@3:qcom,leds@d000                       u:object_r:sysfs_leds:s0
 genfscon sysfs /devices/platform/soc/c440000.qcom,spmi/spmi-0/spmi0-03/c440000.qcom,spmi:qcom,pmi8998@3:qcom,leds@d300                       u:object_r:sysfs_leds:s0


### PR DESCRIPTION
following crosshatch and aosp sepolicy
https://android.googlesource.com/device/google/crosshatch-sepolicy/+/android-9.0.0_r21/vendor/qcom/common/genfs_contexts#69
https://android.googlesource.com/platform/system/sepolicy/+/android-9.0.0_r21/public/file.te#82
https://android.googlesource.com/platform/system/sepolicy/+/android-9.0.0_r21/private/priv_app.te#90

avoid
12-12 20:03:11.079  4235  4235 I IntentService[D: type=1400 audit(0.0:101): avc: denied { open } for path=/sys/devices/platform/soc/18800000.qcom,icnss/net/p2p0/type dev=sysfs ino=63502 scontext=u:r:priv_app:s0:c512,c768 tcontext=u:object_r:sysfs:s0 tclass=file permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>