### PR TITLE
rootdir: vendor: fstab: add encryptable flag for external sdcards

### DIFF
--- a/rootdir/vendor/etc/fstab.tama
+++ b/rootdir/vendor/etc/fstab.tama
@@ -12,6 +12,6 @@
 /dev/block/bootdevice/by-name/bluetooth    /vendor/bt_firmware     vfat    ro,shortname=lower,uid=1002,gid=3002,dmask=227,fmask=337,context=u:object_r:vendor_firmware_file:s0 wait,slotselect
 /dev/block/bootdevice/by-name/persist      /mnt/vendor/persist     ext4    noatime,nosuid,nodev,barrier=1,data=ordered,nodelalloc,errors=panic   wait,notrim
 
-/devices/platform/soc/8804000.sdhci/mmc_host/mmc*                       auto         auto    nosuid,nodev                     voldmanaged=sdcard1:auto
+/devices/platform/soc/8804000.sdhci/mmc_host/mmc*                       auto         auto    nosuid,nodev                     voldmanaged=sdcard1:auto,encryptable=userdata
 /devices/platform/soc/a800000.ssusb/a800000.dwc3/xhci-hcd.0.auto/usb*   auto         auto    defaults                         voldmanaged=usb:auto
 /dev/block/zram0                            none        swap    defaults                                                      zramsize=536870912,notrim


### PR DESCRIPTION
Starting from Android P, it is possible to use FBE in combination with adoptable storage.
This also has the side effect that Android will actually start scanning external sdcards for media.