### PR TITLE
label 8300000.qcom,turing as sysfs_msm_subsys

### DIFF
--- a/sepolicy_platform/genfs_contexts
+++ b/sepolicy_platform/genfs_contexts
@@ -9,6 +9,7 @@ genfscon sysfs /devices/platform/soc/ae00000.qcom,mdss_rotator                  
 genfscon sysfs /devices/platform/soc/4080000.qcom,mss                           u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/platform/soc/c440000.qcom,spmi                          u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/platform/soc/aae0000.qcom,venus                         u:object_r:sysfs_msm_subsys:s0
+genfscon sysfs /devices/platform/soc/8300000.qcom,turing                        u:object_r:sysfs_msm_subsys:s0
 
 genfscon sysfs /devices/platform/soc/ac4a000.qcom,cci                           u:object_r:sysfs_camera:s0
 


### PR DESCRIPTION
following crosshatch https://android.googlesource.com/device/google/crosshatch-sepolicy/+/android-9.0.0_r21/vendor/qcom/common/genfs_contexts#62

avoid
09-28 21:10:07.889   725   725 I pd-mapper: type=1400 audit(0.0:8): avc: denied { read } for name=name dev=sysfs ino=67870 scontext=u:r:pd_mapper:s0 tcontext=u:object_r:sysfs:s0 tclass=file permissive=1
09-28 21:10:07.889   725   725 I pd-mapper: type=1400 audit(0.0:9): avc: denied { open } for path=/sys/devices/platform/soc/8300000.qcom,turing/subsys6/name dev=sysfs ino=67870 scontext=u:r:pd_mapper:s0 tcontext=u:object_r:sysfs:s0 tclass=file permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>