### PR TITLE
label soc:qcom,ipa_fws as sysfs_msm_subsys

### DIFF
--- a/sepolicy_platform/genfs_contexts
+++ b/sepolicy_platform/genfs_contexts
@@ -10,6 +10,7 @@ genfscon sysfs /devices/platform/soc/4080000.qcom,mss                           
 genfscon sysfs /devices/platform/soc/c440000.qcom,spmi                          u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/platform/soc/aae0000.qcom,venus                         u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/platform/soc/8300000.qcom,turing                        u:object_r:sysfs_msm_subsys:s0
+genfscon sysfs /devices/platform/soc/soc:qcom,ipa_fws                           u:object_r:sysfs_msm_subsys:s0
 
 genfscon sysfs /devices/platform/soc/ac4a000.qcom,cci                           u:object_r:sysfs_camera:s0
 

--- a/sepolicy_platform/genfs_contexts
+++ b/sepolicy_platform/genfs_contexts
@@ -11,6 +11,7 @@ genfscon sysfs /devices/platform/soc/c440000.qcom,spmi                          
 genfscon sysfs /devices/platform/soc/aae0000.qcom,venus                         u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/platform/soc/8300000.qcom,turing                        u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/platform/soc/soc:qcom,ipa_fws                           u:object_r:sysfs_msm_subsys:s0
+genfscon sysfs /devices/platform/soc/188101c.qcom,spss                          u:object_r:sysfs_msm_subsys:s0
 
 genfscon sysfs /devices/platform/soc/ac4a000.qcom,cci                           u:object_r:sysfs_camera:s0
 

--- a/sepolicy_platform/genfs_contexts
+++ b/sepolicy_platform/genfs_contexts
@@ -12,6 +12,7 @@ genfscon sysfs /devices/platform/soc/aae0000.qcom,venus                         
 genfscon sysfs /devices/platform/soc/8300000.qcom,turing                        u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/platform/soc/soc:qcom,ipa_fws                           u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/platform/soc/188101c.qcom,spss                          u:object_r:sysfs_msm_subsys:s0
+genfscon sysfs /devices/platform/soc/5c00000.qcom,ssc                           u:object_r:sysfs_msm_subsys:s0
 
 genfscon sysfs /devices/platform/soc/ac4a000.qcom,cci                           u:object_r:sysfs_camera:s0
 


### PR DESCRIPTION
following crosshatch
https://android.googlesource.com/device/google/crosshatch-sepolicy/+/android-9.0.0_r21/vendor/qcom/common/genfs_contexts#60

avoid
10-10 17:55:30.839   728   728 I pm-service: type=1400 audit(0.0:6): avc: denied { open } for path=/sys/devices/platform/soc/soc:qcom,ipa_fws/subsys2/name dev=sysfs ino=51410 scontext=u:r:per_mgr:s0 tcontext=u:object_r:sysfs:s0 tclass=file permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>