### PR TITLE
[tama] fstab: Mount dsp partition read-only

### DIFF
--- a/rootdir/vendor/etc/fstab.tama
+++ b/rootdir/vendor/etc/fstab.tama
@@ -6,7 +6,7 @@
 /dev/block/bootdevice/by-name/oem          /odm         ext4    ro,barrier=1                                                  wait,recoveryonly,slotselect
 /dev/block/bootdevice/by-name/userdata     /data        ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic wait,check,formattable,fileencryption=ice,quota
 /dev/block/bootdevice/by-name/frp          /persistent  emmc    defaults                                                      defaults
-/dev/block/bootdevice/by-name/dsp          /vendor/dsp             ext4    nosuid,nodev,barrier=1,data=ordered,nodelalloc,errors=panic   wait,notrim,slotselect
+/dev/block/bootdevice/by-name/dsp          /vendor/dsp             ext4    ro,nosuid,nodev,barrier=1,data=ordered,nodelalloc,errors=panic   wait,notrim,slotselect
 /dev/block/bootdevice/by-name/misc         /misc        emmc    defaults                                                      defaults
 /dev/block/bootdevice/by-name/modem        /vendor/firmware_mnt    vfat    ro,shortname=lower,uid=1000,gid=1000,dmask=227,fmask=337,context=u:object_r:vendor_firmware_file:s0 wait,slotselect
 /dev/block/bootdevice/by-name/bluetooth    /vendor/bt_firmware     vfat    ro,shortname=lower,uid=1002,gid=3002,dmask=227,fmask=337,context=u:object_r:vendor_firmware_file:s0 wait,slotselect


### PR DESCRIPTION
Since there is no longer a command in init.common.rc that remounts as read-only, set the property directly in fstab.