### PR TITLE
sepolicy: label all smb2/power_supply paths

### DIFF
--- a/sepolicy_platform/genfs_contexts
+++ b/sepolicy_platform/genfs_contexts
@@ -30,4 +30,7 @@ genfscon sysfs /devices/platform/soc/c440000.qcom,spmi/spmi-0/spmi0-00/c440000.q
 genfscon sysfs /devices/platform/soc/c440000.qcom,spmi/spmi-0/spmi0-02/c440000.qcom,spmi:qcom,pmi8998@2:qpnp,fg/power_supply/bms             u:object_r:sysfs_batteryinfo:s0
 genfscon sysfs /devices/platform/soc/c440000.qcom,spmi/spmi-0/spmi0-02/c440000.qcom,spmi:qcom,pmi8998@2:qpnp,fg/capacity                     u:object_r:sysfs_batteryinfo:s0
 genfscon sysfs /devices/platform/soc/c440000.qcom,spmi/spmi-0/spmi0-02/c440000.qcom,spmi:qcom,pmi8998@2:qcom,qpnp-smb2/power_supply/battery  u:object_r:sysfs_batteryinfo:s0
+genfscon sysfs /devices/platform/soc/c440000.qcom,spmi/spmi-0/spmi0-02/c440000.qcom,spmi:qcom,pmi8998@2:qcom,qpnp-smb2/power_supply/dc       u:object_r:sysfs_batteryinfo:s0
+genfscon sysfs /devices/platform/soc/c440000.qcom,spmi/spmi-0/spmi0-02/c440000.qcom,spmi:qcom,pmi8998@2:qcom,qpnp-smb2/power_supply/main     u:object_r:sysfs_batteryinfo:s0
 genfscon sysfs /devices/platform/soc/c440000.qcom,spmi/spmi-0/spmi0-02/c440000.qcom,spmi:qcom,pmi8998@2:qcom,qpnp-smb2/power_supply/pc_port  u:object_r:sysfs_batteryinfo:s0
+genfscon sysfs /devices/platform/soc/c440000.qcom,spmi/spmi-0/spmi0-02/c440000.qcom,spmi:qcom,pmi8998@2:qcom,qpnp-smb2/power_supply/usb      u:object_r:sysfs_batteryinfo:s0


### PR DESCRIPTION
health is trying to read /type under these paths

[    3.964888] type=1400 audit(26114220.939:5): avc: denied { read } for pid=702 comm=android.hardwar name=type dev=sysfs ino=57484 scontext=u:r:hal_health_default:s0 tcontext=u:object_r:sysfs_msm_subsys:s0 tclass=file permissive=0
[    3.966788] type=1400 audit(26114220.939:6): avc: denied { read } for pid=702 comm=android.hardwar name=type dev=sysfs ino=57562 scontext=u:r:hal_health_default:s0 tcontext=u:object_r:sysfs_msm_subsys:s0 tclass=file permissive=0
[    3.967052] type=1400 audit(26114220.939:7): avc: denied { read } for pid=702 comm=android.hardwar name=type dev=sysfs ino=57515 scontext=u:r:hal_health_default:s0 tcontext=u:object_r:sysfs_msm_subsys:s0 tclass=file permissive=0
[    3.967238] type=1400 audit(26114220.939:8): avc: denied { read } for pid=702 comm=android.hardwar name=type dev=sysfs ino=58102 scontext=u:r:hal_health_default:s0 tcontext=u:object_r:sysfs_msm_subsys:s0 tclass=file permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>