### PR TITLE
sepolicy: label wireless_charger as sysfs_batteryinfo

### DIFF
--- a/sepolicy_platform/genfs_contexts
+++ b/sepolicy_platform/genfs_contexts
@@ -34,3 +34,4 @@ genfscon sysfs /devices/platform/soc/c440000.qcom,spmi/spmi-0/spmi0-02/c440000.q
 genfscon sysfs /devices/platform/soc/c440000.qcom,spmi/spmi-0/spmi0-02/c440000.qcom,spmi:qcom,pmi8998@2:qcom,qpnp-smb2/power_supply/main     u:object_r:sysfs_batteryinfo:s0
 genfscon sysfs /devices/platform/soc/c440000.qcom,spmi/spmi-0/spmi0-02/c440000.qcom,spmi:qcom,pmi8998@2:qcom,qpnp-smb2/power_supply/pc_port  u:object_r:sysfs_batteryinfo:s0
 genfscon sysfs /devices/platform/soc/c440000.qcom,spmi/spmi-0/spmi0-02/c440000.qcom,spmi:qcom,pmi8998@2:qcom,qpnp-smb2/power_supply/usb      u:object_r:sysfs_batteryinfo:s0
+genfscon sysfs /devices/platform/soc/a88000.i2c/i2c-0/0-0061/power_supply/wireless                                                           u:object_r:sysfs_batteryinfo:s0


### PR DESCRIPTION
health is trying to access it to read /type

akari:/sys/class/power_supply # ls -l
lrwxrwxrwx 1 root root 0 1970-10-30 11:07 wireless -> ../../devices/platform/soc/a88000.i2c/i2c-0/0-0061/power_supply/wireless

Signed-off-by: David Viteri <davidteri91@gmail.com>