### PR TITLE
PlatformConfig: Remove vfb bootarg for testing fbdev.

### DIFF
--- a/PlatformConfig.mk
+++ b/PlatformConfig.mk
@@ -38,7 +38,6 @@ BOARD_RAMDISK_OFFSET     := 0x02000000
 
 BOARD_KERNEL_CMDLINE += lpm_levels.sleep_disabled=1
 BOARD_KERNEL_CMDLINE += androidboot.bootdevice=1d84000.ufshc
-BOARD_KERNEL_CMDLINE += video=vfb:640x400,bpp=32,memsize=3072000
 BOARD_KERNEL_CMDLINE += msm_drm.dsi_display0=dsi_panel_cmd_display:config0
 BOARD_KERNEL_CMDLINE += swiotlb=2048
 BOARD_KERNEL_CMDLINE += service_locator.enable=1


### PR DESCRIPTION
With https://github.com/sonyxperiadev/kernel-defconfig/pull/27

Virtual framebuffers are used to debug the fbdev system, and should not be used on production devices. It only wastes memory.

Tested on SoMC Akatsuki DSDS (with removal in `tama` repo) and SoMC Discovery SDE.