### PR TITLE
[master] PlatformConfig: Add restore_msm_uart early parameter

### DIFF
--- a/PlatformConfig.mk
+++ b/PlatformConfig.mk
@@ -43,7 +43,7 @@ BOARD_KERNEL_CMDLINE += swiotlb=2048
 BOARD_KERNEL_CMDLINE += service_locator.enable=1
 
 # Serial console
-#BOARD_KERNEL_CMDLINE += earlycon=msm_serial_dm,0xa84000
+#BOARD_KERNEL_CMDLINE += earlycon=msm_serial_dm,0xa84000 restore_msm_uart=0x03404000
 
 TARGET_RECOVERY_WIPE := $(PLATFORM_COMMON_PATH)/rootdir/recovery.wipe
 TARGET_RECOVERY_FSTAB ?= $(PLATFORM_COMMON_PATH)/rootdir/vendor/etc/fstab.tama


### PR DESCRIPTION
Add an early parameter which activates an early function that will
restore the correct pin configuration in the TLMM block on the
UART_TX and UART_RX GPIOs. This will bring back access to the
early console.

Tama platform:
    TLMM start: 0x03400000
    UART TX: GPIO4
    UART TX OFFSET: 0x4000

Reference to: sonyxperiadev/kernel#1907

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>