### PR TITLE
platform: add dtbo to ota partitions

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -60,6 +60,7 @@ PRODUCT_STATIC_BOOT_CONTROL_HAL := \
 
 AB_OTA_PARTITIONS += \
     boot \
+    dtbo \
     system \
     vendor
 


### PR DESCRIPTION
dtbo contains parts of the dt that are prone to being updated just like the dt found in the boot image.
Make sure it is included in ota updates.