### PR TITLE
rootdir: vendor: correct ignored IRQs

### DIFF
--- a/rootdir/vendor/etc/msm_irqbalance.conf
+++ b/rootdir/vendor/etc/msm_irqbalance.conf
@@ -28,5 +28,5 @@
 #
 
 PRIO=1,1,1,1,0,0,0,0
-#arch_timer, arm-pmu, arch_mem_timer, glink_lpass
-IGNORED_IRQ=19,21,38,188
+#arch_timer, arch_mem_timer, arm-pmu
+IGNORED_IRQ=4,6,17


### PR DESCRIPTION
The IRQ numbers set as ignored were wrong and corresponded to interrupts other than the ones listed.