### PR TITLE
[VERIFYME] QCNSS_qcom_cfg: Enable RX thread to receive packet

### DIFF
--- a/rootdir/vendor/firmware/wlan/qca_cld/WCNSS_qcom_cfg.ini
+++ b/rootdir/vendor/firmware/wlan/qca_cld/WCNSS_qcom_cfg.ini
@@ -302,6 +302,12 @@ gSkipDfsChannelInP2pSearch=0
 #Enable or Disable p2p device address administered
 isP2pDeviceAddrAdministrated=1
 
+# RX packet handling options
+# 0: no rx thread, no RPS, for MDM
+# 1: RX thread
+# 2: RPS
+rxhandle=1
+
 # Set Thermal Power limit
 TxPower2g=10
 TxPower5g=10


### PR DESCRIPTION
In present code, RPS is enabled in RX path which is causing inconsistency in TCP DL throughtput case.
Enable RX thread which is providing consistency in throughtput with minimal power impact.

CRs-Fixed: 1018382
Change-Id: Ieac0fec9399375b723c0f350639f861bdbc143a2

See
https://github.com/zuk-devs/android_device_zuk_msm8996-common/commit/8068e96efd64858834dd9fa89757a266587da369
https://github.com/LineageOS/android_device_huawei_kiwi/commit/4058d20590ef4465086460b330fcf1ba30c75906