### PR TITLE
[TAMA-4.14] PlatformConfig: Remove dsi display selection from external cmdline

### DIFF
--- a/PlatformConfig.mk
+++ b/PlatformConfig.mk
@@ -37,7 +37,6 @@ BOARD_RAMDISK_OFFSET     := 0x02000000
 
 BOARD_KERNEL_CMDLINE += lpm_levels.sleep_disabled=1
 BOARD_KERNEL_CMDLINE += androidboot.bootdevice=1d84000.ufshc
-BOARD_KERNEL_CMDLINE += msm_drm.dsi_display0=dsi_panel_cmd_display:config0
 BOARD_KERNEL_CMDLINE += swiotlb=2048
 BOARD_KERNEL_CMDLINE += service_locator.enable=1
 


### PR DESCRIPTION
This is a platform configuration that never changes in the entire life
of a specific kernel version: there is no need to set it in the external
cmdline that comes from the boot image.

Starting from kernel 4.14 this setting is pushed through the bootargs
specified in kernel, in the device-tree for the specific platform.