### PR TITLE
[TAMA] init: Set custom forced LowMemoryKiller minfree params

### DIFF
--- a/rootdir/vendor/etc/init/init.tama.rc
+++ b/rootdir/vendor/etc/init/init.tama.rc
@@ -47,6 +47,9 @@ on boot
     # to one of the CPU from the default IRQ affinity mask.
     write /proc/irq/default_smp_affinity f
 
+    # Set custom LMK parameters
+    write /sys/module/lowmemorykiller/parameters/forced_minfree 14746,18432,22118,25805,34415,43737
+
 on property:sys.boot_completed=1
     # Runtime fs tuning for runtime performance
     write /sys/block/sda/queue/read_ahead_kb 128


### PR DESCRIPTION
This platform kills apps too easily and that's due to the very
aggressive caching that happens in background, which is
totally fine, but there is no point in forcing to have a lot of
free, unused and wasted memory apart a lil faster allocation
in some cases.

In - any - case though, the overhead of having to free memory
by closing userspace apps is way bigger than the overhead that
we get by some memory fragmentation here and there or
reclaim when a very large amount of memory needs to be used
by a very large application.

For this reason, prefer a great instant-app-reopening user
experience over 1% less time to open giant games.

Tested on SoMC Tama Akatsuki RoW