### PR TITLE
camera: Set the hardware variant to `qcom'.

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -138,6 +138,10 @@ PRODUCT_PACKAGES += \
 PRODUCT_PACKAGES += \
     camera.sdm845
 
+# Look for camera.qcom.so instead of camera.$(BOARD_TARGET_PLATFORM).so
+PRODUCT_PROPERTY_OVERRIDES += \
+    ro.hardware.camera=qcom
+
 # QCOM Bluetooth
 PRODUCT_PACKAGES += \
     android.hardware.bluetooth@1.0-impl-qti \


### PR DESCRIPTION
Android 10 changed the way libhardware is allowed to find modules, and
this doesn't work through symlinks anymore. For more information, see
the commit that removes the symlink from hardware/camera/Android.mk in
common, and the relevant change in libhardware:
https://android.googlesource.com/platform/hardware/libhardware/+/e448a05fecab601c59b89a2f948e1ad18050e40f%5E%21/#F0

Instead, set the vendor variant propery, that points libhardware to load
camera.qcom.so from any of the predefined search folders.

### TODO:
I don't think
```make
PRODUCT_PACKAGES += \
    camera.sdm845
```
is warranted anymore.