### PR TITLE
platform: use 64 bit camera implementation

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -135,6 +135,8 @@ PRODUCT_PACKAGES += \
     gps.sdm845
 
 # CAMERA
+TARGET_USES_64BIT_CAMERA := true
+
 PRODUCT_PACKAGES += \
     camera.sdm845
 


### PR DESCRIPTION
The Tama platform requires a 64 bit camera HAL.