### PR TITLE
[TAMA] init.tama.rc: Set 0664 permissions to wlan fwpath

### DIFF
--- a/rootdir/vendor/etc/init/init.tama.rc
+++ b/rootdir/vendor/etc/init/init.tama.rc
@@ -33,6 +33,7 @@ on init
 
 on boot
     # WLAN MAC
+    chmod 0664 /sys/module/wlan/parameters/fwpath
     chown wifi wifi /sys/module/wlan/parameters/fwpath
     chown wifi wifi /sys/kernel/boot_wlan/boot_wlan
 


### PR DESCRIPTION
Grant write permission to group to stop issues when the WiFi HAL
or other components using this is/are started as an user different
from "wifi".