### PR TITLE
[TAMA] platform: Add vbmeta to AB_OTA_PARTITIONS

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -56,7 +56,8 @@ AB_OTA_PARTITIONS += \
     boot \
     dtbo \
     system \
-    vendor
+    vendor \
+    vbmeta
 
 # Treble
 # Include vndk/vndk-sp/ll-ndk modules


### PR DESCRIPTION
When creating an otapackage, we definitely want to also push the
vbmeta in order to get the verifier to work as intended, otherwise
the only solution would be to disable verification in the vbmeta,
leading to big security issues.