### PR TITLE
[TAMA] vendor: rqbalance: Update configuration for Android 10

### DIFF
--- a/rootdir/vendor/etc/rqbalance_config.xml
+++ b/rootdir/vendor/etc/rqbalance_config.xml
@@ -16,12 +16,12 @@
 <rqbalance_config>
 
     <batterysave>
-        <cpuquiet min_cpus="1" max_cpus="3"/>
+        <cpuquiet min_cpus="2" max_cpus="4"/>
         <rqbalance balance_level="80"/>
         <rqbalance down_thresholds="0 120 320 400 440 500 550 700"/>
         <rqbalance   up_thresholds="200 450 550 580 600 640 750 4294967295"/>
         <rqbalance cluster0_freq_min="0"/>
-        <rqbalance cluster0_freq_max="1132800"/>
+        <rqbalance cluster0_freq_max="1324800"/>
         <rqbalance cluster1_freq_min="0"/>
         <rqbalance cluster1_freq_max="1209600"/>
     </batterysave>


### PR DESCRIPTION
Android 10 needs a little more power when executing background
tasks while the device is in power saving mode (display off or battery
saver enabled).

The need for more power is especially seen during bluetooth audio
playback while the display is off.