### PR TITLE
[COMMON] camxoverridesettings: Enable Dual IFE, set results timeout to default

### DIFF
--- a/rootdir/vendor/etc/camera/camxoverridesettings.txt
+++ b/rootdir/vendor/etc/camera/camxoverridesettings.txt
@@ -4,7 +4,5 @@ logVerboseMask=0
 logWarningMask=0
 systemLogEnable=FALSE
 maxHalRequests=9
-enableDualIFE=FALSE
-waitAllResultsTimeout=10
 numPCRsBeforeStreamOn=1
 preFlashMaxFrameWaitLimitAF=45


### PR DESCRIPTION
Let Dual IFE to keep defaults as it's required in some cases.
Set back results timeout to default: 10 is a too small value and
we trigger timeout, producing useless logging and triggering
recovery after some time, hence slowing down the entire UX.