### PR TITLE
rootdir: Move uinput-fpc.kl to devices

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -109,8 +109,7 @@ PRODUCT_COPY_FILES += \
 
 # FPC Gestures
 PRODUCT_COPY_FILES += \
-    $(SONY_ROOT)/vendor/usr/idc/uinput-fpc.idc:$(TARGET_COPY_OUT_VENDOR)/usr/idc/uinput-fpc.idc \
-    $(SONY_ROOT)/vendor/usr/keylayout/uinput-fpc.kl:$(TARGET_COPY_OUT_VENDOR)/usr/keylayout/uinput-fpc.kl
+    $(SONY_ROOT)/vendor/usr/idc/uinput-fpc.idc:$(TARGET_COPY_OUT_VENDOR)/usr/idc/uinput-fpc.idc
 
 # MSM IRQ Balancer configuration file
 PRODUCT_COPY_FILES += \

--- a/rootdir/vendor/usr/keylayout/uinput-fpc.kl
+++ b/rootdir/vendor/usr/keylayout/uinput-fpc.kl
@@ -1,6 +1,0 @@
-key 103   SYSTEM_NAVIGATION_UP
-key 108   SYSTEM_NAVIGATION_DOWN
-# Left and right are swapped, because this is a back-mounted sensor.
-# In other words, the sensor is mirrored relative to the screen.
-key 106   SYSTEM_NAVIGATION_LEFT
-key 105   SYSTEM_NAVIGATION_RIGHT


### PR DESCRIPTION
Apollo's fingerprint sensor is rotated 90 degrees clockwise, as compared to Akari and Akatsuki.

This necessitates two different config files, and as such, the keylayout configs are moved to the individual device gits.

See:
https://github.com/sonyxperiadev/device-sony-apollo/pull/26
https://github.com/sonyxperiadev/device-sony-akari/pull/25
https://github.com/sonyxperiadev/device-sony-akatsuki/pull/21