### PR TITLE
[TAMA] platform: Configure audio buffer for fast mapping

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -223,9 +223,12 @@ PRODUCT_PACKAGES += \
 PRODUCT_PROPERTY_OVERRIDES += \
     vendor.qcom.bluetooth.soc=cherokee
 
-# Fluence
+# Audio - Android System
 PRODUCT_PROPERTY_OVERRIDES += \
-    ro.qc.sdk.audio.fluencetype=fluence
+    aaudio.mmap_policy=2 \
+    aaudio.mmap_exclusive_policy=2 \
+    aaudio.hw_burst_min_usec=2000 \
+    af.fast_track_multiplier=1
 
 # USB controller setup
 PRODUCT_PROPERTY_OVERRIDES += \


### PR DESCRIPTION
Configure the audio buffers for fast mapping, allowing for
latency reduction on audio paths.