### PR TITLE
[master] init: Change boot_wlan permissions to 0660

### DIFF
--- a/rootdir/vendor/etc/init/init.tama.rc
+++ b/rootdir/vendor/etc/init/init.tama.rc
@@ -36,6 +36,7 @@ on boot
     chmod 0664 /sys/module/wlan/parameters/fwpath
     chown wifi wifi /sys/module/wlan/parameters/fwpath
     chown wifi wifi /sys/kernel/boot_wlan/boot_wlan
+    chmod 0660 /sys/kernel/boot_wlan/boot_wlan
 
     # update foreground cpuset now that processors are up
     write /dev/cpuset/foreground/cpus 0-7


### PR DESCRIPTION
After the integration of:

https://android.googlesource.com/platform/hardware/qcom/wlan/+/8996467be9cb5d5ce95dffb156b07fa62fe496cb

the permissions of the /sys/kernel/boot_wlan/boot_wlan file need to be 0660.

Signed-off-by: Pablo Mendez Hernandez <pablomh@gmail.com>