### PR TITLE
platform.mk: Enable sscrpcd & cdsp flags

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -64,6 +64,9 @@ NXP_CHIP_FW_TYPE := PN553
 # Audio
 BOARD_SUPPORTS_SOUND_TRIGGER := true
 
+# DSP
+TARGET_HAS_CDSP := true
+
 # SSC Sensors
 TARGET_USES_SSC := true
 
@@ -75,6 +78,9 @@ NUM_FRAMEBUFFER_SURFACE_BUFFERS := 2
 
 # Lights HAL: Backlight
 TARGET_USES_SDE := true
+
+# Sscrpcd
+TARGET_NEEDS_SSCRPCD := true
 
 # Overlay
 DEVICE_PACKAGE_OVERLAYS += \


### PR DESCRIPTION
#860 in common changes how those modules are enabled.
It adds flags thus we have to follow the changes into
device trees for platform and make sure the needed flags are
set.