### PR TITLE
[t-mr1] Android 13 Wi-Fi fix

### DIFF
--- a/rootdir/vendor/etc/wifi/wpa_supplicant_overlay.conf
+++ b/rootdir/vendor/etc/wifi/wpa_supplicant_overlay.conf
@@ -3,3 +3,4 @@ p2p_disabled=1
 tdls_external_control=1
 wowlan_triggers=magic_pkt
 bss_max_count=400
+driver_param=use_p2p_group_interface=1


### PR DESCRIPTION
etc: wpa_supplicant_overlay: Set driver_param use_p2p_group_interface=1

As supplicant rc entry from external/wpa_supplicant_8 is going to be used, instead of providing param as parameter to service start, use_p2p_group_interface is set in wpa_supplicant conf file.

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>